### PR TITLE
divided flex and pandoc

### DIFF
--- a/asdf-linguist.asd
+++ b/asdf-linguist.asd
@@ -20,7 +20,10 @@
                   :components
                   ((:file "make")))
                  (:file "graphics")
-                 (:file "text"))))
+                 (:module "text"
+                  :components
+                  ((:file "flex")
+                   (:file "pandoc"))))))
   :description "Extensions for ASDF."
   :long-description #.(uiop:read-file-string
                        (uiop:subpathname *load-pathname* "README.md"))

--- a/src/text/flex.lisp
+++ b/src/text/flex.lisp
@@ -1,0 +1,20 @@
+(in-package :asdf-linguist)
+
+(defclass flex (source-file)
+  ((type :initform "l")
+   (output :reader output :initarg :output)))
+
+(defmethod perform ((o load-op) (component flex)) t)
+
+(defmethod output-files ((operation compile-op) (component flex))
+  (values
+   (list
+    (output-pathname component "c"))))
+
+(defmethod perform ((o compile-op) (component flex))
+  (run-command "flex -o ~A ~A"
+               (namestring (output-pathname component "c"))
+               (namestring (component-pathname component))))
+
+(import 'flex :asdf)
+

--- a/src/text/pandoc.lisp
+++ b/src/text/pandoc.lisp
@@ -1,23 +1,5 @@
 (in-package :asdf-linguist)
 
-(defclass flex (source-file)
-  ((type :initform "l")
-   (output :reader output :initarg :output)))
-
-(defmethod perform ((o load-op) (component flex)) t)
-
-(defmethod output-files ((operation compile-op) (component flex))
-  (values
-   (list
-    (output-pathname component "c"))))
-
-(defmethod perform ((o compile-op) (component flex))
-  (run-command "flex -o ~A ~A"
-               (namestring (output-pathname component "c"))
-               (namestring (component-pathname component))))
-
-(import 'flex :asdf)
-
 (defclass pandoc (source-file)
   ((type :initarg :type :reader input-type)
    (input-format :initarg :input-type :reader input-format)


### PR DESCRIPTION
I was working on an org-mode extension after this commit, but stopped here because
I didn't want to mess up with macros-over-methods.
You should use inheritance instead.
