### PR TITLE
Update the rest of the code to the new inferior-shell interface

### DIFF
--- a/asdf-linguist-test.asd
+++ b/asdf-linguist-test.asd
@@ -1,5 +1,6 @@
 (defsystem asdf-linguist-test
-  :author "Fernando Borretti <eudoxiahp@gmail.com>"
+  :author "Fernando Borretti"
+  :mailto "eudoxiahp@gmail.com"
   :license "MIT"
   :defsystem-depends-on (:asdf-linguist)
   :components ((:module "t"

--- a/src/base.lisp
+++ b/src/base.lisp
@@ -2,6 +2,12 @@
   (:use :cl :asdf))
 (in-package :asdf-linguist)
 
+#+nil
+(defun run-command (format-string &rest args)
+  (let ((out (apply #'format (cons nil (cons format-string args)))))
+    (print out)
+    (run-shell-command out)))
+
 (defun output-pathname (component &optional output-type
                                     (name (pathname-name (component-pathname component))))
   (make-pathname
@@ -29,13 +35,16 @@
 
      (import ',name :asdf)))
 
+(defun ensure-list (obj)
+  (if (listp obj) obj (list obj)))
+
 (defmacro define-shell-component (name &key input-type output-type shell-command)
   "Define an ASDF component that's compiled by running a shell command."
   `(define-component ,name
      :input-type ,input-type
      :output-type ,output-type
      :compile-function (lambda (input-pathname output-pathname)
-                         (inferior-shell:run (list ,shell-command
+                         (inferior-shell:run (list ,@(ensure-list shell-command)
                                                     input-pathname
                                                     output-pathname)
                                              :show t))))

--- a/src/base.lisp
+++ b/src/base.lisp
@@ -2,12 +2,6 @@
   (:use :cl :asdf))
 (in-package :asdf-linguist)
 
-#+nil
-(defun run-command (format-string &rest args)
-  (let ((out (apply #'format (cons nil (cons format-string args)))))
-    (print out)
-    (run-shell-command out)))
-
 (defun output-pathname (component &optional output-type
                                     (name (pathname-name (component-pathname component))))
   (make-pathname

--- a/src/build-systems/make.lisp
+++ b/src/build-systems/make.lisp
@@ -1,13 +1,7 @@
 (in-package :asdf-linguist)
 
-(defclass make (source-file)
-  ((target :reader target :initarg :target :initform "")))
-
-(defclass make (source-file) ())
-
-(defmethod perform ((o load-op) (component make)) t)
+(define-component make)
 
 (defmethod perform ((o compile-op) (component make))
-  (run-command "make -f ~A" (component-pathname component)))
-
-(import 'make :asdf)
+  (inferior-shell:run `("make" "-f" ,(component-pathname component))
+                      :show t))

--- a/src/graphics.lisp
+++ b/src/graphics.lisp
@@ -3,7 +3,7 @@
 (define-shell-component ditaa
   :input-type "ditaa"
   :output-type "png"
-  :command-format "ditaa ~A ~A")
+  :shell-command "ditaa")
 
 (defclass dot (source-file)
   ((type :initform "dot")

--- a/src/graphics.lisp
+++ b/src/graphics.lisp
@@ -5,23 +5,8 @@
   :output-type "png"
   :shell-command "ditaa")
 
-(defclass dot (source-file)
-  ((type :initform "dot")
-   (output :reader output :initarg :output)
-   (output-type :initform "png" :accessor output-type :initarg :type)))
-
-(defmethod perform ((o load-op) (component dot)) nil)
-
-(defmethod output-files ((operation compile-op) (component dot))
-  (values
-   (list
-    (output-pathname component (output-type component)))))
-
-(defmethod perform ((o compile-op) (component dot))
-  (run-command "dot -T~A ~A -o ~A"
-               (output-type component)
-               (namestring (component-pathname component))
-               (namestring (output-pathname component
-                                            (output-type component)))))
-
-(import 'dot :asdf)
+(define-component dot
+  :input-type "dot"
+  :output-type "png"
+  :compile-function (lambda (input-pathname output-pathname)
+                      (inferior-shell:run `("dot" "-Tpng" ,input-pathname "-o" ,output-pathname))))

--- a/src/graphics.lisp
+++ b/src/graphics.lisp
@@ -9,4 +9,5 @@
   :input-type "dot"
   :output-type "png"
   :compile-function (lambda (input-pathname output-pathname)
-                      (inferior-shell:run `("dot" "-Tpng" ,input-pathname "-o" ,output-pathname))))
+                      (inferior-shell:run `("dot" "-Tpng" ,input-pathname "-o" ,output-pathname)
+                                          :show t)))

--- a/src/lang/c.lisp
+++ b/src/lang/c.lisp
@@ -8,14 +8,14 @@
 (defmethod perform ((o load-op) (component c->bin)) t)
 
 (defmethod output-files ((operation compile-op) (component c->bin))
-  (values
-   (list
-    (output-pathname component))))
+  (list (output-pathname component)))
 
 (defmethod perform ((o compile-op) (component c->bin))
-  (run-command "cc ~A -o ~A ~{-l~A~}"
-               (namestring (component-pathname component))
-               (namestring (output-pathname component))
-               (link component)))
+  (inferior-shell:run `("cc"
+                        ,(namestring (component-pathname component))
+                        "-o"
+                        (namestring (output-pathname component))
+                        ;;,@(loop for l in (link component) collect (list "-l" l))
+                        (link component))))
 
 (import 'c->bin :asdf)

--- a/src/lang/c.lisp
+++ b/src/lang/c.lisp
@@ -16,6 +16,7 @@
                         "-o"
                         (namestring (output-pathname component))
                         ;;,@(loop for l in (link component) collect (list "-l" l))
-                        (link component))))
+                        (link component))
+                      :show t))
 
 (import 'c->bin :asdf)

--- a/src/text/flex.lisp
+++ b/src/text/flex.lisp
@@ -1,20 +1,6 @@
 (in-package :asdf-linguist)
 
-(defclass flex (source-file)
-  ((type :initform "l")
-   (output :reader output :initarg :output)))
-
-(defmethod perform ((o load-op) (component flex)) t)
-
-(defmethod output-files ((operation compile-op) (component flex))
-  (values
-   (list
-    (output-pathname component "c"))))
-
-(defmethod perform ((o compile-op) (component flex))
-  (run-command "flex -o ~A ~A"
-               (namestring (output-pathname component "c"))
-               (namestring (component-pathname component))))
-
-(import 'flex :asdf)
-
+(define-shell-component flex
+  :input-type "l"
+  :output-type "c"
+  :shell-command ("flex" "-o"))

--- a/src/text/pandoc.lisp
+++ b/src/text/pandoc.lisp
@@ -8,21 +8,21 @@
    (output-extension :initarg :output-extension :reader output-extension)
    (options :initarg :options :reader options :initform "")))
 
-(defmethod perform ((o load-op) (component pandoc)) nil)
+(defmethod perform ((o load-op) (component pandoc)) t)
 
 (defmethod output-files ((operation compile-op) (component pandoc))
-  (list
-   (output-pathname component (output-extension component))))
+  (list (output-pathname component (output-extension component))))
 
 (defmethod perform ((o compile-op) (component pandoc))
-  (run-command "pandoc ~A -f ~A -o ~A ~A ~A"
-               (if (output-type component)
-                   (concatenate 'string "-t " (output-type component))
-                   "")
-               (input-format component)
-               (namestring (output-pathname component
-                                            (output-extension component)))
-               (namestring (component-pathname component))
-               (options component)))
+  (inferior-shell:run
+   `("pandoc" ,@(if (output-type component)
+                    `("-t" ,(output-type component)))
+               "-f"
+               ,(input-format component)
+               "-o"
+               ,(namestring (output-pathname component (output-extension component)))
+               ,(namestring (component-pathname component))
+               ,(options component))
+   :show t))
 
 (import 'pandoc :asdf)

--- a/src/www/css.lisp
+++ b/src/www/css.lisp
@@ -5,23 +5,23 @@
 (define-shell-component less
   :input-type "less"
   :output-type "css"
-  :command-format "lessc ~A ~A")
+  :shell-command "lessc")
 
 ;;; Sass
 
 (define-shell-component sass
   :input-type "scss"
   :output-type "css"
-  :command-format "sass ~A ~A")
+  :shell-command "sass")
 
 (define-shell-component sass-strict
   :input-type "sass"
   :output-type "css"
-  :command-format "sass ~A ~A")
+  :shell-command "sass")
 
 ;;; Myth
 
 (define-shell-component myth
   :input-type "myth"
   :output-type "css"
-  :command-format "myth ~A ~A")
+  :shell-command "myth")

--- a/src/www/js.lisp
+++ b/src/www/js.lisp
@@ -5,14 +5,14 @@
 (define-shell-component coffee
   :input-type "coffee"
   :output-type "js"
-  :command-format "coffee -c ~A #~A")
+  :shell-command ("coffee" "-c"))
 
 ;;; Roy
 
 (define-shell-component roy
   :input-type "roy"
   :output-type "js"
-  :command-format "roy -r ~A #~A")
+  :shell-command ("roy" "-r"))
 
 ;;; Parenscript
 

--- a/src/www/tools.lisp
+++ b/src/www/tools.lisp
@@ -7,7 +7,8 @@
   :output-type "min.css"
   :compile-function (lambda (input-pathname output-pathname)
                       (inferior-shell:run
-                       `("yui-compressor" ,input-pathname "-o" ,output-pathname))))
+                       `("yui-compressor" ,input-pathname "-o" ,output-pathname)
+                       :show t)))
 
 ;;; YUI JS compressor
 
@@ -16,4 +17,5 @@
   :output-type "min.js"
   :compile-function (lambda (input-pathname output-pathname)
                       (inferior-shell:run
-                       `("yui-compressor" ,input-pathname "-o" ,output-pathname))))
+                       `("yui-compressor" ,input-pathname "-o" ,output-pathname)
+                       :show t)))

--- a/src/www/tools.lisp
+++ b/src/www/tools.lisp
@@ -2,14 +2,18 @@
 
 ;;; YUI CSS compressor
 
-(define-shell-component css-minify
+(define-component css-minify
   :input-type "css"
   :output-type "min.css"
-  :command-format "yui-compressor ~A -o ~A")
+  :compile-function (lambda (input-pathname output-pathname)
+                      (inferior-shell:run
+                       `("yui-compressor" ,input-pathname "-o" ,output-pathname))))
 
 ;;; YUI JS compressor
 
-(define-shell-component js-minify
+(define-component js-minify
   :input-type "js"
   :output-type "min.js"
-  :command-format "yui-compressor ~A -o ~A")
+  :compile-function (lambda (input-pathname output-pathname)
+                      (inferior-shell:run
+                       `("yui-compressor" ,input-pathname "-o" ,output-pathname))))

--- a/t/www/css/myth-input.myth
+++ b/t/www/css/myth-input.myth
@@ -1,7 +1,7 @@
 :root {
-  var-mycolor: #ddd;
+  --mycolor: #ddd;
 }
 
 body {
-  color: color(var(mycolor) tint(50%));
+  color: color(var(--mycolor) tint(50%));
 }

--- a/t/www/css/sass-strict-input.sass
+++ b/t/www/css/sass-strict-input.sass
@@ -1,0 +1,5 @@
+$mycolor: #ddd
+
+body 
+  color: $mycolor
+


### PR DESCRIPTION
This PR complements the PR 4 from earlier today: I had only changed the interface but didn't actually updated the code.

As far as I could see, all is complete as in the tests. Only a few things missing:
- the `lang/c.lisp` probably won't work correctly
- I didn't actually ran any code with `text/flex.lisp`

I think it finally closes #1.