### PR TITLE
Fix coffeescript command

### DIFF
--- a/src/www/js.lisp
+++ b/src/www/js.lisp
@@ -2,10 +2,13 @@
 
 ;;; CoffeeScript
 
-(define-shell-component coffee
+(define-component coffee
   :input-type "coffee"
   :output-type "js"
-  :shell-command ("coffee" "-c"))
+  :compile-function (lambda (input-pathname output-pathname)
+                      (declare (ignore output-pathname))
+                      (inferior-shell:run `("coffee" "-c" ,input-pathname)
+                                          :show t)))
 
 ;;; Roy
 


### PR DESCRIPTION
Fix CoffeeScript to how it was before (with the `coffee -c ~A #~A` string). Now it tries to compile the generated `.js` file.
